### PR TITLE
Unused Import

### DIFF
--- a/pythonperlin/perlin.py
+++ b/pythonperlin/perlin.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 import itertools
-import pyutils
 
 
 def smoothstep(x):


### PR DESCRIPTION
Import pyutils is not used, and needs to be unnecessarily installed by the user for using the package